### PR TITLE
One session per operation

### DIFF
--- a/utils/entities/kata.js
+++ b/utils/entities/kata.js
@@ -177,12 +177,8 @@ class Kata {
     return await PG.getValidFollowers(this.id, mode);
   }
 
-  async updateInfo(newData, mode) {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
-
+  async updateInfo(newData, mode, client) {
+    PG.session(client, async (client) => {
       const query = {
         text: `UPDATE history SET  \
           time = $1,           \
@@ -217,14 +213,7 @@ class Kata {
       } else {
         await KataFilesManager.updateKata(this.id, newData);
       }
-
-      await client.query('COMMIT');
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async updateState(client) {

--- a/utils/entities/kata.js
+++ b/utils/entities/kata.js
@@ -102,10 +102,10 @@ class KataFilesManager {
 }
 
 class KatasArray extends Array {
-  async updateState() {
+  async updateState(client) {
     for (const kata of this) {
       //BOTTLENECK
-      await kata.updateState();
+      await kata.updateState(client);
     }
   }
 
@@ -128,20 +128,22 @@ class Kata {
     this.id = options.id;
   }
 
-  async init() {
-    Object.assign(
-      this,
-      this.id
-        ? await PG.queryLine(
-            'SELECT * FROM history, katas WHERE history.kata_id = katas.id AND id = $1',
-            [this.id]
-          )
-        : await PG.queryLine(
-            'SELECT * FROM history, katas WHERE history.kata_id = katas.id AND cid = $1',
-            [this.cid]
-          )
-    );
-    this.valid = Boolean(this.cid && this.id);
+  async init(client) {
+    await PG.session(client, async (client) => {
+      Object.assign(
+        this,
+        this.id
+          ? await client.queryLine(
+              'SELECT * FROM history, katas WHERE history.kata_id = katas.id AND id = $1',
+              [this.id]
+            )
+          : await client.queryLine(
+              'SELECT * FROM history, katas WHERE history.kata_id = katas.id AND cid = $1',
+              [this.cid]
+            )
+      );
+      this.valid = Boolean(this.cid && this.id);
+    });
   }
 
   async getThisMonthInfo() {
@@ -225,12 +227,8 @@ class Kata {
     }
   }
 
-  async updateState() {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
-
+  async updateState(client) {
+    await PG.session(client, async (client) => {
       const settings = await client.queryRows(
         `SELECT hour, day, month from settings WHERE user_id IN (
           SELECT user_id FROM subscription WHERE kata_id = $1
@@ -239,7 +237,7 @@ class Kata {
       );
 
       if (settings.length === 0) {
-        await this.delete();
+        await this.delete(client);
         return;
       }
 
@@ -254,39 +252,19 @@ class Kata {
         ) WHERE kata_id = $1`,
         [this.id, someSettings.hour, someSettings.day, someSettings.month]
       );
-      await client.query('COMMIT');
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
+    });
   }
 
-  async delete() {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
-
+  async delete(client) {
+    await PG.session(client, async (client) => {
       await client.query(`DELETE FROM history WHERE kata_id = $1;`, [this.id]);
       await client.query(`DELETE FROM katas WHERE id = $1;`, [this.id]);
       await KataFilesManager.deleteKata(this.id);
-
-      await client.query('COMMIT');
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
+    });
   }
 
-  static async createKata(cid, kataData = {}) {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
+  static async createKata(cid, kataData = {}, client) {
+    return await PG.session(client, async (client) => {
       const kataId = await client.queryFirst('INSERT INTO katas (cid) VALUES ($1) RETURNING id', [
         cid,
       ]);
@@ -323,15 +301,9 @@ class Kata {
 
       await KataFilesManager.createKata(kataId, kataData);
 
-      await client.query('COMMIT');
-
       return new Kata({ id: kataId });
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
+      // TODO: return inited kata
+    });
   }
 
   static async createKatas(katasData = [], userId) {
@@ -368,16 +340,18 @@ class Kata {
     return katas;
   }
 
-  static async getKatas(ids) {
-    const katasRequest = await PG.query(
-      `SELECT * FROM katas, history WHERE id = kata_id and id IN (${ids.map((id) => `'${id}'`)})`
-    );
+  static async getKatas(ids, client) {
+    return await PG.session(client, async (client) => {
+      const katasRequest = await client.query(
+        `SELECT * FROM katas, history WHERE id = kata_id and id IN (${ids.map((id) => `'${id}'`)})`
+      );
 
-    const katas = new KatasArray(
-      ...katasRequest.rows.map((properties) => Kata.initKataWithProperties(properties))
-    );
+      const katas = new KatasArray(
+        ...katasRequest.rows.map((properties) => Kata.initKataWithProperties(properties))
+      );
 
-    return katas;
+      return katas;
+    });
   }
 }
 

--- a/utils/entities/user.js
+++ b/utils/entities/user.js
@@ -10,46 +10,50 @@ class User {
 
   //Public methods
 
-  async init() {
-    Object.assign(
-      this,
-      await PG.queryLine('SELECT * FROM users, settings WHERE id = user_id AND tg_id = $1', [
-        this.tg_id,
-      ])
-    );
+  async init(client) {
+    await PG.session(client, async (client) => {
+      Object.assign(
+        this,
+        await client.queryLine('SELECT * FROM users, settings WHERE id = user_id AND tg_id = $1', [
+          this.tg_id,
+        ])
+      );
+    });
     this.#valid = Boolean(this.id);
   }
 
-  async addKata(kata) {
-    await SqlSetManager.addPair(this.id, kata.id);
-    await kata.updateState();
+  async addKata(kata, client) {
+    await SqlSetManager.addPair(this.id, kata.id, client);
+    await kata.updateState(client);
   }
 
-  async addKatas(katasArray) {
-    for (const kata of katasArray) {
-      //BOTTLENECK
-      await this.addKata(kata);
-    }
+  async addKatas(katasArray, client) {
+    await PG.session(client, async (client) => {
+      for (const kata of katasArray) {
+        //BOTTLENECK
+        await this.addKata(kata, client);
+      }
+    });
   }
 
-  async deleteKata(kata) {
-    await SqlSetManager.deletePair(this.id, kata.id);
-    await kata.updateState();
+  async deleteKata(kata, client) {
+    await PG.session(client, async (client) => {
+      await SqlSetManager.deletePair(this.id, kata.id, client);
+      await kata.updateState(client);
+    });
   }
 
-  async deleteKatas(katasArray) {
-    for (const kata of katasArray) {
-      //BOTTLENECK
-      await this.deleteKata(kata);
-    }
+  async deleteKatas(katasArray, client) {
+    await PG.session(client, async (client) => {
+      for (const kata of katasArray) {
+        //BOTTLENECK
+        await this.deleteKata(kata, client);
+      }
+    });
   }
 
-  async toggleSettings(mode) {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
-
+  async toggleSettings(mode, client) {
+    await PG.session(client, async (client) => {
       const settings = await client.queryLine(
         `UPDATE settings SET ${mode} = NOT ${mode} WHERE user_id = $1 RETURNING hour, day, month`,
         [this.id]
@@ -57,38 +61,30 @@ class User {
 
       this[mode] = !this[mode];
 
-      await client.query('COMMIT');
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
-
-    const usersKatas = await Kata.getKatas((await this.getKataSet()).toArray());
-    await usersKatas.updateState();
-
-    // After remake Kata's settings updateState will not be necessary
+      const usersKatas = await Kata.getKatas((await this.getKataSet()).toArray(), client);
+      await usersKatas.updateState(client);
+      // After remake Kata's settings updateState will not be necessary
+    });
 
     return this.settings;
   }
 
-  async getKataSet() {
-    return await SqlSetManager.getKataSet(this.id);
+  async getKataSet(client) {
+    return await SqlSetManager.getKataSet(this.id, client);
   }
 
-  async getKataCids() {
-    return await SqlSetManager.getUsersKataCids(this.id);
+  async getKataCids(client) {
+    return await SqlSetManager.getUsersKataCids(this.id, client);
   }
 
-  async getKataIds() {
-    return await SqlSetManager.getUsersKataIds(this.id);
+  async getKataIds(client) {
+    return await SqlSetManager.getUsersKataIds(this.id, client);
   }
 
   //Predicate methods
 
-  async hasKata(kata) {
-    return await SqlSetManager.hasPair(this.id, kata.id);
+  async hasKata(kata, client) {
+    return await SqlSetManager.hasPair(this.id, kata.id, client);
   }
 
   //Private methods
@@ -111,11 +107,8 @@ class User {
 
   //Static methods
 
-  static async createUser(tgId) {
-    const client = await PG.getClient();
-
-    try {
-      await client.query('BEGIN');
+  static async createUser(tgId, client) {
+    return await PG.session(client, async (client) => {
       const userId = await client.queryFirst(`INSERT INTO users (tg_id) VALUES ($1) RETURNING id`, [
         tgId,
       ]);
@@ -129,15 +122,8 @@ class User {
       const user = new User(tgId);
       user.#initArtificially(properties);
 
-      await client.query('COMMIT');
-
       return user;
-    } catch (e) {
-      await client.query('ROLLBACK');
-      throw e;
-    } finally {
-      client.release();
-    }
+    });
   }
 }
 

--- a/utils/menu/kataKatalog.js
+++ b/utils/menu/kataKatalog.js
@@ -4,13 +4,14 @@ import { backButton } from './../keyboards.js';
 import PG from './../pg.js';
 import send from './../send.js';
 import Codewars from './../codewars.js';
+import Kata from '../entities/kata.js';
 
 function generateKataText(info) {
   info.totalVoites = info.votes_very + info.votes_somewhat + info.votes_not;
   info.rating = ((info.votes_very + info.votes_somewhat / 2) / info.totalVoites) * 100;
 
   return `\
-«<a href="${Codewars.getKataLink(info.kata)}"><b>${info.name}</b></a>».\n
+«<a href="${Codewars.getKataLink(info.cid)}"><b>${info.name}</b></a>».\n
 Completed <b>${info.completed}</b> times.
 Stars: <b>${info.stars}</b>
 Comments: <b>${info.comments}</b>
@@ -29,80 +30,59 @@ export default [
     async (ctx) => {
       await ctx.answerCbQuery();
 
-      const client = await PG.getClient();
+      const kataCids = await PG.startSession(async (client) => {
+        return await ctx.session.user.getKataCids(client);
+      });
 
-      try {
-        const kataCids = await ctx.session.user.getKataCids();
-
-        if (ctx.session.kataNames === undefined) {
-          ctx.session.kataNames = {};
-        }
-
-        const newNames = [];
-
-        for (const cid of kataCids) {
-          if (ctx.session.kataNames[cid] === undefined) {
-            const response = Codewars.getKataAPIInfo(cid);
-            newNames.push(response);
-          }
-        }
-
-        if (newNames.length) {
-          await send(ctx, 'Loading...', Markup.inlineKeyboard([backButton('menu')]));
-        }
-
-        for (const name of await Promise.all(newNames)) {
-          ctx.session.kataNames[name.id] = name.name;
-        }
-
-        const katasKeyboard = Object.entries(ctx.session.kataNames).map((kata) => {
-          return [Markup.button.callback(kata[1], `kata_info:${kata[0]}`)];
-        });
-
-        ctx.editMessageText(
-          'Loaded!',
-          Markup.inlineKeyboard([...katasKeyboard, [backButton('menu')]])
-        );
-      } catch (e) {
-        console.error(e);
-      } finally {
-        client.release();
+      if (ctx.session.kataNames === undefined) {
+        ctx.session.kataNames = {};
       }
+
+      const newNames = [];
+
+      for (const cid of kataCids) {
+        if (ctx.session.kataNames[cid] === undefined) {
+          const response = Codewars.getKataAPIInfo(cid);
+          newNames.push(response);
+        }
+      }
+
+      if (newNames.length) {
+        await send(ctx, 'Loading...', Markup.inlineKeyboard([backButton('menu')]));
+      }
+
+      for (const name of await Promise.all(newNames)) {
+        ctx.session.kataNames[name.id] = name.name;
+      }
+
+      const katasKeyboard = Object.entries(ctx.session.kataNames).map((kata) => {
+        return [Markup.button.callback(kata[1], `kata_info:${kata[0]}`)];
+      });
+
+      ctx.editMessageText(
+        'Loaded!',
+        Markup.inlineKeyboard([...katasKeyboard, [backButton('menu')]])
+      );
     },
   ],
   [
     /^kata_info:([a-z\d]{24})$/,
     async (ctx) => {
       await ctx.answerCbQuery();
-      const kata = ctx.match[1];
+      const cid = ctx.match[1];
       const options = {
         parse_mode: 'HTML',
         disable_web_page_preview: true,
         reply_markup: Markup.inlineKeyboard([backButton('kata_katalog')]).reply_markup,
       };
 
-      const client = await PG.getClient();
+      PG.startSession(async (client) => {
+        const kata = new Kata({ cid });
+        await kata.init(client);
+        kata.name = ctx.session.kataNames[cid];
 
-      try {
-        await client.query('BEGIN');
-
-        const kataData = await client.queryLine(
-          `SELECT * FROM history WHERE kata_id = (SELECT id FROM katas WHERE cid = $1)`,
-          [kata]
-        );
-        await send(
-          ctx,
-          generateKataText({ ...kataData, kata: kata, name: ctx.session.kataNames[kata] }),
-          options
-        );
-
-        await client.query('COMMIT');
-      } catch (e) {
-        await client.query('ROLLBACK');
-        console.error(e);
-      } finally {
-        client.release();
-      }
+        send(ctx, generateKataText(kata), options);
+      });
     },
   ],
 ];

--- a/utils/menu/notificationSettings.js
+++ b/utils/menu/notificationSettings.js
@@ -21,25 +21,14 @@ export default [
     async (ctx) => {
       const mode = ctx.match[1];
       const user = ctx.session.user;
-      const client = await PG.getClient();
 
-      try {
-        await client.query('BEGIN');
-        await ctx.answerCbQuery();
+      await ctx.answerCbQuery();
 
-        const settings = await user.toggleSettings(mode);
+      const settings = await user.toggleSettings(mode);
 
-        console.log('[Toggle notification]', ctx.session.user.id, '[mode]', mode);
+      console.log('[Toggle notification]', ctx.session.user.id, '[mode]', mode);
 
-        await ctx.editMessageReplyMarkup(settingsKb(settings).reply_markup);
-
-        await client.query('COMMIT');
-      } catch (e) {
-        await client.query('ROLLBACK');
-        throw e;
-      } finally {
-        client.release();
-      }
+      await ctx.editMessageReplyMarkup(settingsKb(settings).reply_markup);
     },
   ],
 ];

--- a/utils/sqlSet.js
+++ b/utils/sqlSet.js
@@ -85,34 +85,37 @@ class SqlSetManager {
     return userSet;
   }
 
-  static async hasPair(userId, kataId) {
-    return PG.queryFirst(`SELECT $1 IN (SELECT kata_id FROM subscription WHERE user_id = $2)`, [
-      kataId,
-      userId,
-    ]);
+  static async hasPair(userId, kataId, client) {
+    return await client.queryFirst(
+      `SELECT $1 IN (SELECT kata_id FROM subscription WHERE user_id = $2)`,
+      [kataId, userId]
+    );
   }
 
-  static async addPair(userId, kataId) {
-    await PG.query('INSERT INTO subscription (user_id, kata_id) VALUES ($1, $2)', [userId, kataId]);
-  }
-
-  static async deletePair(userId, kataId) {
-    await PG.query('DELETE FROM subscription WHERE user_id = $1 AND kata_id = $2', [
+  static async addPair(userId, kataId, client) {
+    await client.query('INSERT INTO subscription (user_id, kata_id) VALUES ($1, $2)', [
       userId,
       kataId,
     ]);
   }
 
-  static async getUsersKataCids(userId) {
-    return await PG.queryColumn(
+  static async deletePair(userId, kataId, client) {
+    await client.query('DELETE FROM subscription WHERE user_id = $1 AND kata_id = $2', [
+      userId,
+      kataId,
+    ]);
+  }
+
+  static async getUsersKataCids(userId, client) {
+    return await client.queryColumn(
       `SELECT cid FROM katas WHERE id IN (
         SELECT kata_id from ${nameDB} WHERE user_id = $1
       )`,
       [userId]
     );
   }
-  static async getUsersKataIds(userId) {
-    return await PG.queryColumn(`SELECT kata_id from ${nameDB} WHERE user_id = $1`, [userId]);
+  static async getUsersKataIds(userId, client) {
+    return await client.queryColumn(`SELECT kata_id from ${nameDB} WHERE user_id = $1`, [userId]);
   }
 
   // TODO: create methods:

--- a/utils/userManager.js
+++ b/utils/userManager.js
@@ -7,20 +7,24 @@ import User from './entities/user.js';
 async function initUser(ctx) {
   const tgId = ctx.from.id;
 
-  let user = new User(tgId);
-  await user.init();
+  const user = await PG.startSession(async (client) => {
+    let user = new User(tgId);
+    await user.init(client);
 
-  if (user.valid === false) {
-    user = await User.createUser(tgId);
-    console.log('[New user]', tgId, user.id);
-    await ctx.reply(
-      `\
+    if (user.valid === false) {
+      user = await User.createUser(tgId, client);
+      console.log('[New user]', tgId, user.id);
+
+      await ctx.reply(
+        `\
 Welcome to the bot for tracking changes in your katas in Codewars.
 It is very important to me that users are happy with their interaction with the bot, \
 so you can tell me about your experiences, bugs or suggestions.`,
-      mainMenuKb()
-    );
-  }
+        mainMenuKb()
+      );
+    }
+    return user;
+  });
 
   ctx.session.user = user;
 


### PR DESCRIPTION
Each sequence of database queries must be in one session.
This pull request implements such a capability.

If you want to start a new session, call **PG.startSession()**.
A runtime function that accepts the _client_ should be supplied as input.
This _client_ can be used for database queries.
The _client_ can and should be passed to other functions so that they use the same session when accessing the database.
 
If a pre-generated _client_ is passed to a function, call **PG.session()**.
The _client_ and the function to execute that accepts the _client_ should be passed as input.

The last argument to both functions is the function that is called when an error occurs.

If an error occurs inside the session, **client.query('ROLLBACK')** is automatically called.